### PR TITLE
Add endpoint put trigger mode

### DIFF
--- a/ansto_simplon_api/routes/detector/config.py
+++ b/ansto_simplon_api/routes/detector/config.py
@@ -8,6 +8,7 @@ from ...schemas.configuration import (
     SimplonRequestFloat,
     SimplonRequestInt,
     SimplonRequestStr,
+    TriggerMode,
 )
 from ...simulate_zmq_stream import zmq_start_message, zmq_stream
 
@@ -327,9 +328,14 @@ async def put_threshold_energy(input: SimplonRequestDict):
 # threshold / difference / upper_threshold
 
 
-# @router.put("/trigger_mode")
 @router.get("/trigger_mode")
 async def get_trigger_mode():
+    return {"value": zmq_stream.detector_config.detector_trigger_mode}
+
+
+@router.put("/trigger_mode")
+async def put_trigger_mode(input: TriggerMode):
+    zmq_stream.detector_config.detector_trigger_mode = input.value
     return {"value": zmq_stream.detector_config.detector_trigger_mode}
 
 

--- a/ansto_simplon_api/schemas/configuration.py
+++ b/ansto_simplon_api/schemas/configuration.py
@@ -4,6 +4,10 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 
+class TriggerMode(BaseModel):
+    value: Literal["ints", "inte", "exts", "exte", "eies", "extg"]
+
+
 class ROIMode(BaseModel):
     value: Literal["disabled", "4M"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "ansto-simplon-api"
-version = "0.3.9"
+version = "0.3.10"
 source = { editable = "." }
 dependencies = [
     { name = "bitshuffle" },


### PR DESCRIPTION
This PR adds a `put` endpoint for `trigger_mode`. In practice, this doesn't change any functionality for the detector, but my use case requires this endpoint to be called without any errors